### PR TITLE
Fix clipboard serializer overrides `window.parent`

### DIFF
--- a/src/core/plugins/markdown-serializer.js
+++ b/src/core/plugins/markdown-serializer.js
@@ -141,6 +141,7 @@ export function markdownSerializer() {
 				let { selection } = state;
 				let { $from } = selection;
 				let depth = $from.depth;
+				let parent;
 				do {
 					parent = $from.node(depth);
 					depth--;


### PR DESCRIPTION
Since `parent` was not defined here, `window.parent` would end up being used and code here would end up working as expected. However this value leaking here affects other code elsewhere, such as code verifying message source in `index.*.js`.