### PR TITLE
Web library integration stage 3

### DIFF
--- a/src/core/editor-core.js
+++ b/src/core/editor-core.js
@@ -93,6 +93,7 @@ class EditorCore {
 		this.options = options;
 		this.reloaded = options.reloaded;
 		this.readOnly = options.readOnly;
+		this.disableDrag = options.disableDrag;
 		this.isAttachmentNote = options.isAttachmentNote;
 		this.unsaved = options.unsaved;
 		this.docChanged = false;
@@ -220,7 +221,7 @@ class EditorCore {
 					placeholder({
 						text: options.placeholder
 					}),
-					...(this.readOnly ? [] : [drag()]),
+					...((this.readOnly || this.disableDrag) ? [] : [drag()]),
 					tableEditing(),
 					history(),
 					markdownSerializer(),

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 
 // Work around firefox bug that stops up/down navigation in contenteditable to work
 export function refocusEditor(callback) {
@@ -412,4 +413,12 @@ export function removeDiacritics(str) {
 
 export function mod(n, m) {
 	return ((n % m) + m) % m;
+}
+
+export function usePrevious(value) {
+	const ref = useRef();
+	useEffect(() => {
+		ref.current = value;
+	});
+	return ref.current;
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -409,3 +409,7 @@ export function removeDiacritics(str) {
 	}
 	return chars;
 }
+
+export function mod(n, m) {
+	return ((n % m) + m) % m;
+}

--- a/src/index.web.js
+++ b/src/index.web.js
@@ -16,6 +16,7 @@ class EditorInstance {
 		window._currentEditorInstance = this;
 		this.instanceID = options.instanceID;
 		this._readOnly = options.readOnly;
+		this._disableDrag = options.disableDrag;
 		this._localizedStrings = options.localizedStrings;
 		this._editorCore = null;
 
@@ -39,6 +40,7 @@ class EditorInstance {
 		this._editorCore = new EditorCore({
 			value,
 			readOnly: this._readOnly,
+			disableDrag: this._disableDrag,
 			unsaved: false,
 			placeholder: '',
 			isAttachmentNote: false,

--- a/src/ui/editor.js
+++ b/src/ui/editor.js
@@ -29,14 +29,17 @@ function Editor(props) {
 	}, []);
 
 	const handleInsertTable = useCallback(() => {
+		props.editorCore.view.dom.focus();
 		props.editorCore.pluginState.table.insertTable(2, 2);
 	}, [props.editorCore]);
 
 	const handleInsertMath = useCallback(() => {
+		props.editorCore.view.dom.focus();
 		props.editorCore.insertMath()
 	}, [props.editorCore]);
 
 	const handleInsertImage = useCallback(() => {
+		props.editorCore.view.dom.focus();
 		props.editorCore.pluginState.image.openFilePicker();
 	}, [props.editorCore]);
 

--- a/src/ui/toolbar-elements/button.js
+++ b/src/ui/toolbar-elements/button.js
@@ -32,8 +32,14 @@ export const Button = forwardRef(({ icon, title, active, className, triggerOnMou
 	);
 });
 
-export function StateButton({ icon, title, state }) {
+export function StateButton({ icon, title, state, ...rest }) {
 	return (
-		<Button icon={icon} title={title} active={state.isActive} onClick={() => state.run()}/>
+		<Button
+			{ ...rest }
+			icon={icon}
+			title={title}
+			active={state.isActive}
+			onClick={() => state.run()}
+		/>
 	);
 }

--- a/src/ui/toolbar-elements/button.js
+++ b/src/ui/toolbar-elements/button.js
@@ -1,11 +1,12 @@
 'use strict';
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import cx from 'classnames';
 
-export function Button({ icon, title, active, className, triggerOnMouseDown, onClick }) {
+export const Button = forwardRef(({ icon, title, active, className, triggerOnMouseDown, onClick, ...rest }, ref) => {
 	return (
 		<button
+			{ ...rest }
 			className={cx('toolbar-button', { active: !!active }, className)}
 			title={title}
 			onClick={(event) => {
@@ -24,11 +25,12 @@ export function Button({ icon, title, active, className, triggerOnMouseDown, onC
 				}
 				onClick();
 			}}
+			ref={ref}
 		>
 			{icon}
 		</button>
 	);
-}
+});
 
 export function StateButton({ icon, title, state }) {
 	return (

--- a/src/ui/toolbar-elements/colors-dropdown.js
+++ b/src/ui/toolbar-elements/colors-dropdown.js
@@ -32,6 +32,7 @@ export default function ColorsDropdown({ colorState }) {
 		>
 			<div className="grid">
 				{clear && <button
+					role="menuitem"
 					className="color-button"
 					title={intl.formatMessage({ id: 'noteEditor.removeColor' })}
 					onClick={handleColorClear}
@@ -40,15 +41,17 @@ export default function ColorsDropdown({ colorState }) {
 				</button>}
 				{
 					colorState.state.availableColors.map(([name, code], i) => {
+						const isActive = colorState.state.activeColors.includes(code);
 						return (
 							<button
+								role="menuitem"
 								key={i}
 								className="color-button"
 								title={name ? intl.formatMessage({ id: 'general.' + name }) : code}
 								onClick={() => handleColorPick(code)}
 								onMouseDown={(event) => event.preventDefault()}
 							>
-								<IconColor color={code[0] === '#' ? code.slice(0, 7) : code} active={colorState.state.activeColors.includes(code)}/>
+								<IconColor color={code[0] === '#' ? code.slice(0, 7) : code} active={isActive}/>
 							</button>
 						)
 					})

--- a/src/ui/toolbar-elements/dropdown.js
+++ b/src/ui/toolbar-elements/dropdown.js
@@ -3,13 +3,18 @@
 import cx from 'classnames';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from './button';
+import { mod, usePrevious } from '../../core/utils';
 
 export default function Dropdown({ className, icon, title, children }) {
 	const [show, setShow] = useState(false);
+	const prevShow = usePrevious(show);
 	const rootRef = useRef();
+	const childWrapRef = useRef(null);
+	const buttonRef = useRef(null);
+	const lastFocusedIndex = useRef(0);
 
-	const handleMouseDownCallback = useCallback(handleMouseDown, []);
-	const handleKeyDownCallback = useCallback(handleKeyDown, []);
+	const handleMouseDownCallback = useCallback(handleGlobalMouseDown, []);
+	const handleKeyDownCallback = useCallback(handleGlobalKeyDown, []);
 
 	useEffect(() => {
 		window.addEventListener('mousedown', handleMouseDownCallback);
@@ -20,17 +25,40 @@ export default function Dropdown({ className, icon, title, children }) {
 		};
 	}, [handleMouseDownCallback]);
 
-	function handleMouseDown(event) {
+	const getCandidateNodes = useCallback(() =>
+		Array.from(childWrapRef.current?.querySelectorAll('button:not([disabled])') ?? []),
+	[]);
+
+	useEffect(() => {
+		if (show && !prevShow) {
+			const candidates = getCandidateNodes();
+			candidates.forEach(n => node => node.tabIndex = "-1");
+			const nextNode = childWrapRef.current.querySelector('button.active:not([disabled])')
+				?? childWrapRef.current.querySelector('button:not([disabled])');
+
+			if(nextNode) {
+				lastFocusedIndex.current = candidates.indexOf(nextNode);
+				nextNode.focus();
+			}
+		}
+	}, [show, prevShow]);
+
+	function handleGlobalMouseDown(event) {
 		let parent = event.target;
 		while (parent && parent !== rootRef.current) parent = parent.parentNode;
 		if (!parent) {
+			// put focus back on the dropdown button, then move focus again as expected. This now
+			// triggers blur-related cleanup in toolbar prior to the destruction of a popup
+			buttonRef.current.focus();
+			event.target.focus();
 			setShow(false);
 		}
 	}
 
-	function handleKeyDown(event) {
+	function handleGlobalKeyDown(event) {
 		if (event.key === 'Escape') {
 			setShow(false);
+			buttonRef.current.focus();
 		}
 	}
 
@@ -42,10 +70,48 @@ export default function Dropdown({ className, icon, title, children }) {
 		setShow(false);
 	}
 
+	const handleKeyDown = useCallback((ev) => {
+		const candidates = getCandidateNodes();
+		if (!candidates.length) {
+			return;
+		}
+
+		if (ev.key === 'ArrowUp' && lastFocusedIndex.current === 0) {
+			setShow(false);
+			buttonRef.current.focus();
+			ev.stopPropagation();
+			return;
+		}
+		else if (ev.key === 'ArrowUp' || ev.key === 'ArrowLeft') {
+			lastFocusedIndex.current = mod((lastFocusedIndex.current - 1), candidates.length);
+		}
+		else if (ev.key === 'ArrowDown' || ev.key === 'ArrowRight') {
+			lastFocusedIndex.current = mod((lastFocusedIndex.current + 1), candidates.length);
+		}
+		if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(ev.key)) {
+			candidates?.[lastFocusedIndex.current].focus();
+			ev.stopPropagation();
+		}
+	}, [show, getCandidateNodes]);
+
+	const handleButtonKeyDown = useCallback((ev) => {
+		if (ev.key === 'ArrowDown' && !show) {
+			setShow(true);
+		}
+	}, [show]);
+
 	return (
-		<div ref={rootRef} className={cx('dropdown', className)}>
-			<Button icon={icon} title={title} active={show} triggerOnMouseDown={true} onClick={handleButtonDown}/>
-			{show && <div className="popup" onClick={handlePopupClick}>
+		<div ref={rootRef} className={cx('dropdown', className)} onKeyDown={handleKeyDown}>
+			<Button
+				ref={buttonRef}
+				icon={icon}
+				title={title}
+				active={show}
+				triggerOnMouseDown={true}
+				onClick={handleButtonDown}
+				onKeyDown={handleButtonKeyDown}
+			/>
+			{show && <div ref={childWrapRef} className="popup" onClick={handlePopupClick}>
 				{children}
 			</div>}
 		</div>

--- a/src/ui/toolbar-elements/dropdown.js
+++ b/src/ui/toolbar-elements/dropdown.js
@@ -110,8 +110,10 @@ export default function Dropdown({ className, icon, title, children }) {
 				triggerOnMouseDown={true}
 				onClick={handleButtonDown}
 				onKeyDown={handleButtonKeyDown}
+				aria-haspopup="true"
+				aria-expanded={show ? 'true' : 'false'}
 			/>
-			{show && <div ref={childWrapRef} className="popup" onClick={handlePopupClick}>
+			{show && <div ref={childWrapRef} role="menu" className="popup" onClick={handlePopupClick}>
 				{children}
 			</div>}
 		</div>

--- a/src/ui/toolbar-elements/insert-dropdown.js
+++ b/src/ui/toolbar-elements/insert-dropdown.js
@@ -16,18 +16,21 @@ export default function InsertDropdown({ onInsertTable, onInsertMath, onInsertIm
 			title={intl.formatMessage({id: 'general.insert'})}
 		>
 			<button
+				role="menuitem"
 				className="toolbar-button"
 				title={intl.formatMessage({ id: 'noteEditor.insertImage' })}
 				onClick={onInsertImage}
 				onMouseDown={(event) => event.preventDefault()}
 			><IconImage /></button>
 			<button
+				role="menuitem"
 				className="toolbar-button"
 				title={intl.formatMessage({ id: 'noteEditor.insertTable' })}
 				onClick={onInsertTable }
 				onMouseDown={(event) => event.preventDefault()}
 			><IconTable /></button>
 			<button
+				role="menuitem"
 				className="toolbar-button"
 				title={intl.formatMessage({ id: 'noteEditor.insertMath' })}
 				onClick={onInsertMath}

--- a/src/ui/toolbar-elements/text-dropdown.js
+++ b/src/ui/toolbar-elements/text-dropdown.js
@@ -40,21 +40,25 @@ export default function TextDropdown({ menuState }) {
 			<div className="inline-options">
 				<div className="line">
 					<StateButton
+						role="menuitem"
 						icon={<IconBold/>}
 						title={intl.formatMessage({ id: 'noteEditor.bold' })}
 						state={menuState.strong}
 					/>
 					<StateButton
+						role="menuitem"
 						icon={<IconItalic/>}
 						title={intl.formatMessage({ id: 'noteEditor.italic' })}
 						state={menuState.em}
 					/>
 					<StateButton
+						role="menuitem"
 						icon={<IconUnderline/>}
 						title={intl.formatMessage({ id: 'noteEditor.underline' })}
 						state={menuState.underline}
 					/>
 					<StateButton
+						role="menuitem"
 						icon={<IconStrike/>}
 						title={intl.formatMessage({ id: 'noteEditor.strikethrough' })}
 						state={menuState.strike}
@@ -62,16 +66,19 @@ export default function TextDropdown({ menuState }) {
 				</div>
 				<div className="line">
 					<StateButton
+						role="menuitem"
 						icon={<IconSubscript/>}
 						title={intl.formatMessage({ id: 'noteEditor.subscript' })}
 						state={menuState.subscript}
 					/>
 					<StateButton
+						role="menuitem"
 						icon={<IconSuperscript/>}
 						title={intl.formatMessage({ id: 'noteEditor.superscript' })}
 						state={menuState.superscript}
 					/>
 					<StateButton
+						role="menuitem"
 						icon={<IconCode/>}
 						title={intl.formatMessage({ id: 'noteEditor.monospaced' })}
 						state={menuState.code}
@@ -81,6 +88,7 @@ export default function TextDropdown({ menuState }) {
 			<div className="block-options">
 				{blockTypes.map(([type, element], index) => (
 					<button
+						role="menuitem"
 						key={index}
 						className={cx('option', { active: menuState[type].isActive })}
 						onClick={() => handleItemPick(type)}

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -24,18 +24,19 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 	const intl = useIntl();
 	const toolbarRef = useRef(null);
 	const lastFocusedIndex = useRef(0);
-	const isFocused = useRef(false);
 
 	const getCandidateNodes = useCallback(() =>
-		Array.from(toolbarRef.current.querySelectorAll('button:not([disabled])')), []
+		Array.from(toolbarRef.current.querySelectorAll('button:not([disabled])')).filter(n => !n.closest('.popup')), []
 	);
 
 	const handleFocus = useCallback((ev) => {
 		if (viewMode !== 'web') {
 			return;
 		}
-		isFocused.current = true;
 		const candidateNodes = getCandidateNodes();
+		if(!candidateNodes.includes(ev.target)) {
+			return;
+		}
 		candidateNodes.forEach(node => node.tabIndex = "-1");
 		candidateNodes?.[lastFocusedIndex.current].focus();
 	}, [viewMode, getCandidateNodes]);
@@ -45,7 +46,7 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 			return;
 		}
 		const candidateNodes = getCandidateNodes();
-		if (candidateNodes.includes(ev.relatedTarget)) {
+		if (ev.relatedTarget?.closest('.toolbar') === toolbarRef.current) {
 			return;
 		}
 		toolbarRef.current.querySelectorAll('button').forEach(node => node.removeAttribute('tabindex'));
@@ -62,7 +63,9 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 		else if (ev.key === 'ArrowRight') {
 			lastFocusedIndex.current = mod((lastFocusedIndex.current + 1), candidateNodes.length);
 		}
-		candidateNodes?.[lastFocusedIndex.current].focus();
+		if (['ArrowLeft', 'ArrowRight'].includes(ev.key)) {
+			candidateNodes?.[lastFocusedIndex.current].focus();
+		}
 	}, [viewMode, getCandidateNodes]);
 
 	return (

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -75,6 +75,8 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 			onBlur={handleBlur}
 			onKeyDown={handleKeyDown}
 			ref={toolbarRef}
+			role="toolbar"
+			aria-orientation="horizontal"
 		>
 			<div className="start">
 				{enableReturnButton &&


### PR DESCRIPTION
This third and, I believe, last stage of changes related to web library integration, here is a summary:

* **[All Platforms]** If a dropdown is opened using keyboard, make it possible to select option from a list using arrow keys. 
* **[All Platforms]** Add option to disable `drag()` plugin. This is used in web library on touch devices.
* **[All Platforms]** Add hints for screen readers.
* **[Web Library]** Change how focus works in the toolbar. Toolbar is a single tab stop, i.e. `Tab` and `Shift + Tab`  move Move focus into and out of the toolbar. Individual buttons can be focused using arrow keys. This is consistent with behaviour of other toolbars is web library and is based on ARIA Authoring Practices Guide. 

Any comments/suggestions - please let me know.