### PR TITLE
Enable arrow-keys nav in toolbar on all platforms

### DIFF
--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -30,9 +30,6 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 	);
 
 	const handleFocus = useCallback((ev) => {
-		if (viewMode !== 'web') {
-			return;
-		}
 		const candidateNodes = getCandidateNodes();
 		if(!candidateNodes.includes(ev.target)) {
 			return;
@@ -42,9 +39,6 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 	}, [viewMode, getCandidateNodes]);
 
 	const handleBlur = useCallback((ev) => {
-		if (viewMode !== 'web') {
-			return;
-		}
 		const candidateNodes = getCandidateNodes();
 		if (ev.relatedTarget?.closest('.toolbar') === toolbarRef.current) {
 			return;
@@ -53,9 +47,6 @@ function Toolbar({ viewMode, enableReturnButton, colorState, menuState, linkStat
 	}, [viewMode]);
 
 	const handleKeyDown = useCallback((ev) => {
-		if (viewMode !== 'web') {
-			return;
-		}
 		const candidateNodes = getCandidateNodes();
 		if (ev.key === 'ArrowLeft') {
 			lastFocusedIndex.current = mod((lastFocusedIndex.current - 1), candidateNodes.length);


### PR DESCRIPTION
This PR enables arrow-key based navigation in toolbar (93324ed1) on other platforms. That means that toolbar is a single tab stop and arrow keys are used to move between buttons.

I've tested Zotero with this change and it works fine in `master` branch. Couldn't test in `fx102` because something else is messing with focus in there (even before all the web-library related changes), see #49.