### PR TITLE
Tweak web version so it accepts isAttachmentNote

### DIFF
--- a/src/index.web.js
+++ b/src/index.web.js
@@ -18,6 +18,7 @@ class EditorInstance {
 		this._readOnly = options.readOnly;
 		this._disableDrag = options.disableDrag;
 		this._localizedStrings = options.localizedStrings;
+		this._isAttachmentNote = options.isAttachmentNote || false;
 		this._editorCore = null;
 
 		this._init(options.value);
@@ -43,7 +44,7 @@ class EditorInstance {
 			disableDrag: this._disableDrag,
 			unsaved: false,
 			placeholder: '',
-			isAttachmentNote: false,
+			isAttachmentNote: this._isAttachmentNote,
 			onSubscribe: (subscription) => {
 				let { id, type, data } = subscription;
 				subscription = { id, type, data };

--- a/src/ui/editor.js
+++ b/src/ui/editor.js
@@ -51,6 +51,7 @@ function Editor(props) {
 				textColorState={editorState.textColor}
 				highlightColorState={editorState.highlightColor}
 				menuState={editorState.menu}
+				isAttachmentNote={props.editorCore.isAttachmentNote}
 				linkState={editorState.link}
 				citationState={editorState.citation}
 				unsaved={editorState.core.unsaved}

--- a/src/ui/toolbar-elements/insert-dropdown.js
+++ b/src/ui/toolbar-elements/insert-dropdown.js
@@ -6,7 +6,7 @@ import { useIntl } from 'react-intl';
 import { IconInsert, IconImage, IconMath, IconTable } from '../icons';
 import Dropdown from './dropdown';
 
-export default function InsertDropdown({ onInsertTable, onInsertMath, onInsertImage }) {
+export default function InsertDropdown({ isAttachmentNote, onInsertTable, onInsertMath, onInsertImage }) {
 	const intl = useIntl();
 
 	return (
@@ -15,13 +15,13 @@ export default function InsertDropdown({ onInsertTable, onInsertMath, onInsertIm
 			icon={<IconInsert />}
 			title={intl.formatMessage({id: 'general.insert'})}
 		>
-			<button
+			{ !isAttachmentNote && <button
 				role="menuitem"
 				className="toolbar-button"
 				title={intl.formatMessage({ id: 'noteEditor.insertImage' })}
 				onClick={onInsertImage}
 				onMouseDown={(event) => event.preventDefault()}
-			><IconImage /></button>
+			><IconImage /></button> }
 			<button
 				role="menuitem"
 				className="toolbar-button"

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -20,7 +20,7 @@ import TextColorDropdown from './toolbar-elements/text-color-dropdown';
 import InsertDropdown from './toolbar-elements/insert-dropdown';
 import { mod } from '../core/utils';
 
-function Toolbar({ viewMode, enableReturnButton, textColorState, highlightColorState, menuState, linkState, citationState, unsaved, searchState, onClickReturn, onShowNote, onOpenWindow, onInsertTable, onInsertMath, onInsertImage }) {
+function Toolbar({ viewMode, enableReturnButton, textColorState, highlightColorState, menuState, isAttachmentNote, linkState, citationState, unsaved, searchState, onClickReturn, onShowNote, onOpenWindow, onInsertTable, onInsertMath, onInsertImage }) {
 	const intl = useIntl();
 	const toolbarRef = useRef(null);
 	const lastFocusedIndex = useRef(0);
@@ -104,6 +104,7 @@ function Toolbar({ viewMode, enableReturnButton, textColorState, highlightColorS
 					title={intl.formatMessage({ id: 'noteEditor.findAndReplace' })}
 				/>
 				{viewMode === 'web' && <InsertDropdown
+					isAttachmentNote={isAttachmentNote}
 					onInsertTable={ onInsertTable }
 					onInsertMath={ onInsertMath }
 					onInsertImage={ onInsertImage }


### PR DESCRIPTION
Changes done in c84bebf don't seem to apply to the web version because `isAttachmentNote` seems to be always set to `false` in the web build. This PR changes it so it's taken as an option.

Also removed the option to add an image via toolbar in this scenario.

Part of a fix for https://github.com/zotero/web-library/issues/494