### PR TITLE
a11y: announce when link popup appears

### DIFF
--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -162,4 +162,5 @@ export default {
 	'noteEditor.insertImage': 'Insert Image',
 	'noteEditor.insertTable': 'Insert Table',
 	'noteEditor.insertMath': 'Insert Math Block',
+	'noteEditor.a11yLinkPopupAppearedAlert': 'Link popup appeared. Use Shift-Tab to navigate it.'
 };

--- a/src/stylesheets/components/ui/_editor.scss
+++ b/src/stylesheets/components/ui/_editor.scss
@@ -42,5 +42,11 @@
 				}
 			}
 		}
+		
+		#a11y-alert {
+			width: 0;
+			height: 0;
+			overflow: hidden;
+		}
 	}
 }

--- a/src/ui/editor.js
+++ b/src/ui/editor.js
@@ -88,6 +88,9 @@ function Editor(props) {
 					</Fragment>}
 				</div>
 			</div>
+			<div id='a11y-alert' aria-live='polite'>
+				{editorState.link.popup.active ? intl.formatMessage({ id: 'noteEditor.a11yLinkPopupAppearedAlert' }) : ""}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Per https://forums.zotero.org/discussion/122292/feature-request-allow-alt-enter-to-open-links-in-notes-for-accessibility, screen reader users have no way of knowing that the popup is there, and that shift-tab would allow them to edit/open/remove the link.

Addresses: zotero/zotero#5199

This adds an announcement that screen readers read out instructing the user to Shift-Tab to get to the link popup. This is what the announcement sounds like. The actual phrasing may need to be tweaked a bit to be more informative?

https://github.com/user-attachments/assets/b5c68080-ce7f-4f5d-8da8-f32dd1c99eba

