### PR TITLE
Handle pasted annotations in window.clipboardData

### DIFF
--- a/src/core/plugins/drop-paste.js
+++ b/src/core/plugins/drop-paste.js
@@ -129,7 +129,7 @@ export function dropPaste(options) {
 			handlePaste(view, event, slice) {
 				let { state, dispatch } = view;
 				let data;
-				if (data = event.clipboardData.getData('zotero/annotation')) {
+				if (data = event.clipboardData.getData('zotero/annotation') || window.clipboardData?.['zotero/annotation']) {
 					options.onInsertObject('zotero/annotation', data);
 					return true;
 				}


### PR DESCRIPTION
Handle `zotero/annotation` data set when annotation itemTree rows are copy-pasted.
Needed for: https://github.com/zotero/zotero/pull/5274