### PR TITLE
fix: math block auto cleanup

### DIFF
--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -453,7 +453,7 @@ export function setCitation(nodeID, citation) {
 }
 
 // Triggers note serialization and updates citation node views
-export function touchCitations() {
+export function touchCitations(options = {}) {
 	return function (state, dispatch) {
 		let { tr } = state;
 		state.doc.descendants((node, pos) => {
@@ -471,6 +471,9 @@ export function touchCitations() {
 		});
 		tr.setMeta('addToHistory', false);
 		tr.setMeta('system', true);
+		if (options.suppressMathCleanup) {
+			tr.setMeta('suppressMathCleanup', true);
+		}
 		dispatch(tr);
 	}
 }

--- a/src/core/editor-core.js
+++ b/src/core/editor-core.js
@@ -582,6 +582,7 @@ class EditorCore {
 			// Mark this as a system transaction to avoid triggering save
 			tr = tr.setMeta('system', true);
 			tr = tr.setMeta('externalUpdate', true);
+			tr = tr.setMeta('suppressMathCleanup', true);
 
 			let schemaTr = null;
 			try {
@@ -595,13 +596,14 @@ class EditorCore {
 			
 			// Apply schema tr if needed
 			if (schemaTr) {
+				schemaTr = schemaTr.setMeta('suppressMathCleanup', true);
 				this.view.dispatch(schemaTr);
 			}
 
 			// Force citation nodes to re-render since metadata was updated
 			// This ensures annotations with citations display properly
 			if (!this.readOnly) {
-				touchCitations()(this.view.state, this.view.dispatch);
+				touchCitations({ suppressMathCleanup: true })(this.view.state, this.view.dispatch);
 			}
 
 			if (preserveSelection && selectionInfo) {
@@ -647,7 +649,7 @@ class EditorCore {
 							let selectionTr = this.view.state.tr.setSelection(TextSelection.between(
 								this.view.state.doc.resolve(newAnchor),
 								this.view.state.doc.resolve(newHead)
-							));
+							)).setMeta('suppressMathCleanup', true);
 							this.view.dispatch(selectionTr);
 						}
 					}

--- a/src/core/plugins/math.js
+++ b/src/core/plugins/math.js
@@ -3,11 +3,14 @@ import { schema } from '../schema';
 
 class Math {
 	constructor(state, options) {
-
+		this.suppressCleanup = false;
 	}
 
 	update(newState, oldState) {
 		if (!this.view) {
+			return;
+		}
+		if (this.suppressCleanup) {
 			return;
 		}
 		let { dispatch } = this.view;
@@ -39,6 +42,7 @@ export function math(options) {
 				return new Math(state, options);
 			},
 			apply(tr, pluginState, oldState, newState) {
+				pluginState.suppressCleanup = !!tr.getMeta('suppressMathCleanup');
 				return pluginState;
 			}
 		},

--- a/src/core/plugins/schema-transform.js
+++ b/src/core/plugins/schema-transform.js
@@ -4,7 +4,14 @@ import { schemaTransform } from '../schema/transformer';
 export function transform(options) {
 	return new Plugin({
 		appendTransaction(transactions, oldState, newState) {
-			return schemaTransform(newState);
+			let tr = schemaTransform(newState);
+			if (!tr) {
+				return null;
+			}
+			if (transactions.some(tr => tr.getMeta('suppressMathCleanup'))) {
+				tr.setMeta('suppressMathCleanup', true);
+			}
+			return tr;
 		}
 	});
 }


### PR DESCRIPTION
Fixes an issue where math blocks were automatically removed approximately 2 seconds after insertion. This was frequently‌ (but not 100%) reproducible in standalone notes and occasionally in item notes.

https://github.com/user-attachments/assets/434ef490-88f5-4528-93fd-493597b74cac

